### PR TITLE
Zk error handling

### DIFF
--- a/rollout_test.go
+++ b/rollout_test.go
@@ -65,7 +65,7 @@ func makeZK() *zookeeper.Conn {
 }
 
 func makeRollout(zk *zookeeper.Conn) Client {
-	rollout := NewClient(zk, path)
+	rollout := NewClient(zk, path, nil)
 	// 1 == ephemeral
 	zk.Create(path, "{}", 1, zookeeper.WorldACL(zookeeper.PERM_ALL))
 	err := rollout.Start()


### PR DESCRIPTION
In the case of a ZK error a callback will be made if supplied. This lets the application decide what it should do. This should be app termination in the short term. In the longer term we may want to look at disconnecting from ZK, reconnecting, etc.

This also introduces a 1s delay after receiving an error from ZK so that we don't hot spin.

cc @lucky 