### PR TITLE
Float percentages compatibility

### DIFF
--- a/rollout.go
+++ b/rollout.go
@@ -114,11 +114,12 @@ func (r *client) FeatureActive(feature string, userId int64, userGroups []string
 	if contains("all", featureGroups) {
 		return true
 	}
-	percentage, err := strconv.Atoi(splitResult[0])
+	percentageFloat, err := strconv.ParseFloat(splitResult[0], 64)
 	if err != nil {
 		log.Println("Rollout: Invalid percentage: ", splitResult[0])
 		return false
 	}
+	percentage := int(percentageFloat)
 	// Short-circuit for 100%
 	if percentage == 100 {
 		return true

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -40,10 +40,10 @@ func TestAll(t *testing.T) {
 
 func TestPercentage(t *testing.T) {
 	groups := []string{"foo"}
-	setData(`{"feature:hello": "0||"}`)
+	setData(`{"feature:hello": "0.0||"}`)
 	assert(t, !rollout.FeatureActive("hello", 1, groups), "feature should not be active")
 	assert(t, !rollout.FeatureActive("hello", 2, groups), "feature should not be active")
-	setData(`{"feature:hello": "25||"}`)
+	setData(`{"feature:hello": "25.0||"}`)
 	assert(t, rollout.FeatureActive("hello", 1, groups), "feature should be active")
 	assert(t, !rollout.FeatureActive("hello", 26, groups), "feature should not be active")
 	assert(t, !rollout.FeatureActive("nosuchfeature", 1, groups), "feature should not be active")


### PR DESCRIPTION
Add float percentages compatibility to resolve `Rollout: Invalid percentage:  0.0` errors.

```
librato/rollout-go [feature/float-percentages] » go test -v .
2016/06/28 15:27:54 Starting Rollout service on /rollout-go-test
=== RUN   TestUserId
--- PASS: TestUserId (0.10s)
=== RUN   TestGroup
--- PASS: TestGroup (0.11s)
=== RUN   TestAll
--- PASS: TestAll (0.10s)
=== RUN   TestPercentage
--- PASS: TestPercentage (0.31s)
PASS
ok  	github.com/librato/rollout-go	0.637s
```

cc @akahn 