### PR TITLE
Add "RawPercentage" method

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,35 +2,55 @@
 
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
   branch = "master"
+  digest = "1:4d92d3bcd412de705100c10f0428a0b63b12f3d12455ebae46e9ea384c23b333"
   name = "github.com/samuel/go-zookeeper"
   packages = ["zk"]
+  pruneopts = "UT"
   revision = "c4fab1ac1bec58281ad0667dc3f0907a9476ac47"
 
 [[projects]]
+  digest = "1:9e9193aa51197513b3abcb108970d831fbcf40ef96aa845c4f03276e1fa316d2"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "UT"
   revision = "5ba7f63082460102a45837dbd1827e10f9479ac0"
 
 [[projects]]
   branch = "master"
+  digest = "1:8fbfc6ea1a8a078697633be97f07dd83a83d32a96959d42195464c13c25be374"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "UT"
   revision = "c11f84a56e43e20a78cee75a7c034031ecf57d1f"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "91d82a56d2c3a3569dc3e63360734b71f2d24a0406cfb2d4d4a6a88590fcdf46"
+  input-imports = [
+    "github.com/pkg/errors",
+    "github.com/samuel/go-zookeeper/zk",
+    "github.com/sirupsen/logrus",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/rollout.go
+++ b/rollout.go
@@ -2,6 +2,7 @@ package rollout
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -112,6 +113,9 @@ func (r *client) swapData(data []byte) error {
 	return nil
 }
 
+// ErrFeatureNotFound can be detected to inform better defaulting behaviors
+var ErrFeatureNotFound = errors.New("feature not found")
+
 // RawPercentage returns the raw percentage from the rollout section
 func (r *client) RawPercentage(feature string) (float64, error) {
 	feature = "feature:" + feature
@@ -120,7 +124,7 @@ func (r *client) RawPercentage(feature string) (float64, error) {
 	r.RUnlock()
 
 	if !ok {
-		return 0.0, fmt.Errorf("feature not found: %s", feature)
+		return 0.0, ErrFeatureNotFound
 	}
 	splitResult := strings.Split(value, "|")
 	if len(splitResult) != 3 {

--- a/rollout.go
+++ b/rollout.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"log"
 
 	"github.com/samuel/go-zookeeper/zk"
@@ -18,6 +16,7 @@ import (
 type Client interface {
 	Start() error
 	Stop()
+	RawPercentage(feature string) (float64, error)
 	FeatureActive(feature string, userId int64, userGroups []string) bool
 }
 
@@ -121,15 +120,15 @@ func (r *client) RawPercentage(feature string) (float64, error) {
 	r.RUnlock()
 
 	if !ok {
-		return 0.0, errors.New(fmt.Sprintf("feature not found: %s", feature))
+		return 0.0, fmt.Errorf("feature not found: %s", feature)
 	}
 	splitResult := strings.Split(value, "|")
 	if len(splitResult) != 3 {
-		return 0.0, errors.New(fmt.Sprintf("invalid value for %s: %s", feature, value))
+		return 0.0, fmt.Errorf("invalid value for %s: %s", feature, value)
 	}
 	percentageFloat, err := strconv.ParseFloat(splitResult[0], 64)
 	if err != nil {
-		return 0.0, errors.Wrap(err, fmt.Sprintf("rollout invalid percentage: %v", splitResult[0]))
+		return 0.0, fmt.Errorf("rollout invalid percentage: %v", splitResult[0])
 	}
 	return percentageFloat, nil
 }

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -80,7 +80,7 @@ func TestRawPercentage(t *testing.T) {
 		assert(t, r == 0.0, "rawpercentage bad data (values) test b0rked")
 		assert(t, e != nil, "rawpercentage bad data (values) test got nil error")
 		assert(t,
-			e.Error() == "rollout invalid percentage: dorkfish: strconv.ParseFloat: parsing \"dorkfish\": invalid syntax",
+			e.Error() == "rollout invalid percentage: dorkfish",
 			fmt.Sprintf("rawpercentage missing org test got wrong error: %v", e.Error()))
 	})
 }

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -62,8 +62,9 @@ func TestRawPercentage(t *testing.T) {
 		assert(t, r == 0.0, "rawpercentage missing org test broken")
 		assert(t, e != nil, "rawpercentage missing org test got nil error")
 		assert(t,
-			e.Error() == "feature not found: feature:percentage_111111",
+			e.Error() == "feature not found",
 			fmt.Sprintf("rawpercentage missing org test got wrong error: %v", e.Error()))
+		assert(t, e == ErrFeatureNotFound, "wrong error returned")
 	})
 	t.Run("bad data (splits)", func(t *testing.T) {
 		rollout.swapData([]byte(`{"feature:percentage_123456": "75.0|"}`))

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -51,36 +51,36 @@ func TestPercentage(t *testing.T) {
 func TestRawPercentage(t *testing.T) {
 	rollout := &client{currentData: make(map[string]string)}
 	t.Run("happy path", func(t *testing.T) {
-		rollout.swapData([]byte(`{"feature:apm_sample_rate_factor_org123456": "75.0||"}`))
-		r, e := rollout.RawPercentage("apm_sample_rate_factor_org123456")
-		assert(t, r == 75.0, "rawpercentage happy path test b0rked")
+		rollout.swapData([]byte(`{"feature:percentage_123456": "75.0||"}`))
+		r, e := rollout.RawPercentage("percentage_123456")
+		assert(t, r == 75.0, "rawpercentage happy path test broken")
 		assert(t, e == nil, "rawpercentage happy path test got non-nil error")
 	})
 	t.Run("missing org", func(t *testing.T) {
-		rollout.swapData([]byte(`{"feature:apm_sample_rate_factor_org123456": "75.0||"}`))
-		r, e := rollout.RawPercentage("apm_sample_rate_factor_org111111")
-		assert(t, r == 0.0, "rawpercentage missing org test b0rked")
+		rollout.swapData([]byte(`{"feature:percentage_123456": "75.0||"}`))
+		r, e := rollout.RawPercentage("percentage_111111")
+		assert(t, r == 0.0, "rawpercentage missing org test broken")
 		assert(t, e != nil, "rawpercentage missing org test got nil error")
 		assert(t,
-			e.Error() == "feature not found: feature:apm_sample_rate_factor_org111111",
+			e.Error() == "feature not found: feature:percentage_111111",
 			fmt.Sprintf("rawpercentage missing org test got wrong error: %v", e.Error()))
 	})
 	t.Run("bad data (splits)", func(t *testing.T) {
-		rollout.swapData([]byte(`{"feature:apm_sample_rate_factor_org123456": "75.0|"}`))
-		r, e := rollout.RawPercentage("apm_sample_rate_factor_org123456")
-		assert(t, r == 0.0, "rawpercentage bad data (splits) test b0rked")
+		rollout.swapData([]byte(`{"feature:percentage_123456": "75.0|"}`))
+		r, e := rollout.RawPercentage("percentage_123456")
+		assert(t, r == 0.0, "rawpercentage bad data (splits) test broken")
 		assert(t, e != nil, "rawpercentage bad data (splits) test got nil error")
 		assert(t,
-			e.Error() == "invalid value for feature:apm_sample_rate_factor_org123456: 75.0|",
+			e.Error() == "invalid value for feature:percentage_123456: 75.0|",
 			fmt.Sprintf("rawpercentage missing org test got wrong error: %v", e.Error()))
 	})
 	t.Run("bad data (values)", func(t *testing.T) {
-		rollout.swapData([]byte(`{"feature:apm_sample_rate_factor_org123456": "dorkfish||"}`))
-		r, e := rollout.RawPercentage("apm_sample_rate_factor_org123456")
-		assert(t, r == 0.0, "rawpercentage bad data (values) test b0rked")
+		rollout.swapData([]byte(`{"feature:percentage_123456": "garbage||"}`))
+		r, e := rollout.RawPercentage("percentage_123456")
+		assert(t, r == 0.0, "rawpercentage bad data (values) test broken")
 		assert(t, e != nil, "rawpercentage bad data (values) test got nil error")
 		assert(t,
-			e.Error() == "rollout invalid percentage: dorkfish",
+			e.Error() == "rollout invalid percentage: garbage",
 			fmt.Sprintf("rawpercentage missing org test got wrong error: %v", e.Error()))
 	})
 }

--- a/rollout_test.go
+++ b/rollout_test.go
@@ -1,6 +1,7 @@
 package rollout
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -45,6 +46,43 @@ func TestPercentage(t *testing.T) {
 	assert(t, rollout.FeatureActive("hello", 1, groups), "feature should be active")
 	assert(t, rollout.FeatureActive("hello", 26, groups), "feature should be active")
 	assert(t, !rollout.FeatureActive("nosuchfeature", 1, groups), "feature should not be active")
+}
+
+func TestRawPercentage(t *testing.T) {
+	rollout := &client{currentData: make(map[string]string)}
+	t.Run("happy path", func(t *testing.T) {
+		rollout.swapData([]byte(`{"feature:apm_sample_rate_factor_org123456": "75.0||"}`))
+		r, e := rollout.RawPercentage("apm_sample_rate_factor_org123456")
+		assert(t, r == 75.0, "rawpercentage happy path test b0rked")
+		assert(t, e == nil, "rawpercentage happy path test got non-nil error")
+	})
+	t.Run("missing org", func(t *testing.T) {
+		rollout.swapData([]byte(`{"feature:apm_sample_rate_factor_org123456": "75.0||"}`))
+		r, e := rollout.RawPercentage("apm_sample_rate_factor_org111111")
+		assert(t, r == 0.0, "rawpercentage missing org test b0rked")
+		assert(t, e != nil, "rawpercentage missing org test got nil error")
+		assert(t,
+			e.Error() == "feature not found: feature:apm_sample_rate_factor_org111111",
+			fmt.Sprintf("rawpercentage missing org test got wrong error: %v", e.Error()))
+	})
+	t.Run("bad data (splits)", func(t *testing.T) {
+		rollout.swapData([]byte(`{"feature:apm_sample_rate_factor_org123456": "75.0|"}`))
+		r, e := rollout.RawPercentage("apm_sample_rate_factor_org123456")
+		assert(t, r == 0.0, "rawpercentage bad data (splits) test b0rked")
+		assert(t, e != nil, "rawpercentage bad data (splits) test got nil error")
+		assert(t,
+			e.Error() == "invalid value for feature:apm_sample_rate_factor_org123456: 75.0|",
+			fmt.Sprintf("rawpercentage missing org test got wrong error: %v", e.Error()))
+	})
+	t.Run("bad data (values)", func(t *testing.T) {
+		rollout.swapData([]byte(`{"feature:apm_sample_rate_factor_org123456": "dorkfish||"}`))
+		r, e := rollout.RawPercentage("apm_sample_rate_factor_org123456")
+		assert(t, r == 0.0, "rawpercentage bad data (values) test b0rked")
+		assert(t, e != nil, "rawpercentage bad data (values) test got nil error")
+		assert(t,
+			e.Error() == "rollout invalid percentage: dorkfish: strconv.ParseFloat: parsing \"dorkfish\": invalid syntax",
+			fmt.Sprintf("rawpercentage missing org test got wrong error: %v", e.Error()))
+	})
 }
 
 func assert(t *testing.T, condition bool, explanation interface{}) {


### PR DESCRIPTION
### what this is

Sometimes it's helpful to know the raw percentage rather than a simple enabled/not enabled. This PR adds a method that allows a caller to identify the percentage of accounts a feature has been enabled for.

### what this isn't
This feature does not attempt to parse user groups or organization IDs to make assessments about percentages. It simply reports the raw percentage from the feature's rollout description.

